### PR TITLE
Fix redirect for treating it like a path instead of subdomain, preser…

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -165,7 +165,7 @@
 
 #subdomain article redirects
 # https://blog.marklreyes.com/upgrading-a-legacy-angular-web-app/	/blog/upgrading-a-legacy-angular-web-app	301!
-/blog.marklreyes.com/* 						https://marklreyes.com/blog 301!
+https://blog.marklreyes.com/* 				https://marklreyes.com/blog/:splat 301!
 
 #fallback
 /*              									https://marklreyes.com


### PR DESCRIPTION
…ve paths with splat

The rule is redirecting incorrectly because it's treating "blog.marklreyes.com" as a path instead of a subdomain due to the leading slash, and it's missing the ":splat" parameter to preserve path components.